### PR TITLE
Add per-cpu support for map lookup

### DIFF
--- a/c_src/bpf_sys.c
+++ b/c_src/bpf_sys.c
@@ -78,7 +78,10 @@ ERL_NIF_TERM ATOM_NIL;
 static int bpf_sys_load(ErlNifEnv* env, void** priv, ERL_NIF_TERM info_term)
 {
     libbpf_set_strict_mode(LIBBPF_STRICT_ALL);
+
+#ifdef BPF_SYS_LIBBPF_NO_PRINT
     libbpf_set_print(NULL);
+#endif
 
     ATOM_OK = enif_make_atom(env, "ok");
     ATOM_ERROR = enif_make_atom(env, "error");

--- a/c_src/bpf_sys.h
+++ b/c_src/bpf_sys.h
@@ -61,4 +61,14 @@ static inline ERL_NIF_TERM bpf_sys_make_error(ErlNifEnv* env, ERL_NIF_TERM term)
     return enif_make_tuple2(env, ATOM_ERROR, term);
 }
 
+static inline size_t bpf_sys_align_backward(size_t size, size_t alignment)
+{
+    return size - (size % alignment);
+}
+
+static inline size_t bpf_sys_align_forward(size_t size, size_t alignment)
+{
+    return bpf_sys_align_backward(size + (alignment - 1), alignment);
+}
+
 #endif

--- a/c_src/bpf_sys_enum.c
+++ b/c_src/bpf_sys_enum.c
@@ -77,6 +77,19 @@ bool bpf_sys_atom_to_map_type(ErlNifEnv* env, ERL_NIF_TERM term, enum bpf_map_ty
     return false;
 }
 
+bool bpf_sys_map_is_per_cpu(enum bpf_map_type type)
+{
+    switch (type) {
+    case BPF_MAP_TYPE_PERCPU_ARRAY:
+    case BPF_MAP_TYPE_PERCPU_HASH:
+    case BPF_MAP_TYPE_PERCPU_CGROUP_STORAGE:
+    case BPF_MAP_TYPE_LRU_PERCPU_HASH:
+        return true;
+    default:
+        return false;
+    }
+}
+
 ERL_NIF_TERM bpf_sys_attach_type_to_atom(ErlNifEnv* env, enum bpf_attach_type type)
 {
     return attach_types[type].atom;

--- a/c_src/bpf_sys_enum.h
+++ b/c_src/bpf_sys_enum.h
@@ -12,6 +12,8 @@ ERL_NIF_TERM bpf_sys_map_type_to_atom(ErlNifEnv* env, enum bpf_map_type type);
 
 bool bpf_sys_atom_to_map_type(ErlNifEnv* env, ERL_NIF_TERM term, enum bpf_map_type* type);
 
+bool bpf_sys_map_is_per_cpu(enum bpf_map_type type);
+
 ERL_NIF_TERM bpf_sys_link_type_to_atom(ErlNifEnv* env, enum bpf_link_type type);
 
 bool bpf_sys_atom_to_link_type(ErlNifEnv* env, ERL_NIF_TERM term, enum bpf_link_type* type);

--- a/c_src/bpf_sys_map.c
+++ b/c_src/bpf_sys_map.c
@@ -38,6 +38,8 @@ NIF(map_type_nif)
     return bpf_sys_map_type_to_atom(env, type);
 }
 
+static ERL_NIF_TERM map_lookup_elem_percpu(ErlNifEnv* env, bpf_sys_map_t* map, ErlNifBinary key_bin, size_t value_size);
+
 NIF(map_lookup_elem_nif)
 {
     bpf_sys_map_t* map;
@@ -57,6 +59,11 @@ NIF(map_lookup_elem_nif)
         return bpf_sys_make_error(env, enif_make_atom(env, "einval"));
     }
 
+    enum bpf_map_type map_type = bpf_map__type(map->handle);
+    if (bpf_sys_map_is_per_cpu(map_type)) {
+        return map_lookup_elem_percpu(env, map, key_bin, value_size);
+    }
+
     ERL_NIF_TERM value_term;
     uint8_t* value_buf = enif_make_new_binary(env, value_size, &value_term);
 
@@ -65,6 +72,45 @@ NIF(map_lookup_elem_nif)
     }
 
     return bpf_sys_make_ok(env, value_term);
+}
+
+static ERL_NIF_TERM map_lookup_elem_percpu(ErlNifEnv* env, bpf_sys_map_t* map, ErlNifBinary key_bin, size_t value_size)
+{
+    ERL_NIF_TERM result;
+
+    int num_cpus = libbpf_num_possible_cpus();
+    if (num_cpus < 0) {
+        return bpf_sys_make_error(env, enif_make_atom(env, "invalid_num_cpus"));
+    }
+
+    size_t aligned_value_size = bpf_sys_align_forward(value_size, 8);
+    size_t values_size = aligned_value_size * num_cpus;
+
+    ERL_NIF_TERM values_term;
+    uint8_t* values_buf = enif_make_new_binary(env, value_size, &values_term);
+
+    ERL_NIF_TERM* values_terms = enif_alloc(sizeof(*values_terms) * num_cpus);
+    if (!values_terms) {
+        result = errno_to_result(env);
+        goto cleanup_end;
+    }
+
+    if (bpf_map__lookup_elem(map->handle, key_bin.data, key_bin.size, values_buf, values_size, 0) < 0) {
+        result = errno_to_result(env);
+        goto cleanup_values_terms;
+    }
+
+    for (size_t i = 0; i < num_cpus; ++i) {
+        values_terms[i] = enif_make_sub_binary(env, values_term, i * aligned_value_size, aligned_value_size);
+    }
+
+    result = bpf_sys_make_ok(env, enif_make_list_from_array(env, values_terms, num_cpus));
+
+cleanup_values_terms:
+    enif_free(values_terms);
+cleanup_end:
+
+    return result;
 }
 
 NIF(map_update_elem_nif)


### PR DESCRIPTION
Per-CPU maps are a bit different, in the sense that they need to return all the values for each processor core from the lookup.

There is no need to fear breakage with previous versions, as previsouly lookup on a per-cpu map would fail due to an invalid buffer size.  We now return a list of all the values for a per-cpu map, instead of the value directly.